### PR TITLE
Bug 1189583 - [Nexus 4] Add support for the blobfree build

### DIFF
--- a/imaging_tools.js
+++ b/imaging_tools.js
@@ -210,6 +210,11 @@ ImagingTools.prototype = {
       args.push("--dt", options.dt);
     }
 
+    if (options.extraArguments) {
+      let extraArguments = options.extraArguments.trim().split(/ +/);
+      args = args.concat(extraArguments);
+    }
+
     args.push("--output", options.output);
 
     return new Promise((resolve, reject) => {
@@ -237,7 +242,8 @@ ImagingTools.prototype = {
       ./make_ext4fs `cat "${DEVICE}-cmdline-fs.txt" | grep ^system|cut -d':' -f2` "system.img" "${IMAGE_DIR}/SYSTEM/"
     **/
 
-    let args = options.cmdline_fs.split(" ");
+    // cmdline_fs may include multiple spaces between arguments
+    let args = options.cmdline_fs.split(/ +/);
     args.push(options.image);
     args.push(options.source);
 


### PR DESCRIPTION
Adds support for the cmdline-fs.txt file specifying boot.img and recovery.img
options. Fixes issues where two spaces in a cmdline-fs option would cause
subprocess.js to incorrectly assume that the arguments list had terminated.
