### PR TITLE
Bug 1275065 - Unsafe innerHTML usage in b2gInstaller r=gerard-majax

### DIFF
--- a/about.xhtml
+++ b/about.xhtml
@@ -31,6 +31,15 @@
         <ul id="devices"></ul>
         <ul id="noDevice"></ul>
         <input id="userBuild" type="file" value="Upload your own build" />
+        <template id="buildItemTemplate">
+          <li><label class="build">
+            <input type="radio" value="" name="build" /><!-- value: build.url -->
+            <div class="description">
+              <h4></h4><!-- build.name  -->
+              <span></span><!-- build.description -->
+            </div>
+          </label></li>
+        </template>
       </section>
 
       <section class="flash">

--- a/test/mochitest/test_devices.html
+++ b/test/mochitest/test_devices.html
@@ -63,7 +63,7 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1235459
     return new Promise((resolve, reject) => {
       let devices = c.getElementById("devices");
       ok(devices, "has devices node");
-      is(devices.childNodes.length, 2, "two builds available");
+      is(devices.childElementCount, 2, "two builds available");
 
       let url, name, desc;
       url  = devices.getElementsByTagName("input")[0].value;

--- a/test/mochitest/test_devices_unkown.html
+++ b/test/mochitest/test_devices_unkown.html
@@ -50,11 +50,11 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1235459
 
       let devices = c.getElementById("devices");
       ok(devices, "has devices node");
-      is(devices.childNodes.length, 0, "no build available");
+      is(devices.childElementCount, 0, "no build available");
 
       let noDevice = c.getElementById("noDevice");
       ok(noDevice, "has noDevice node");
-      is(noDevice.childNodes.length, 1, "one element for no device");
+      is(noDevice.childElementCount, 1, "one element for no device");
 
       let unsupportedDeviceName = c.querySelector("#noDevice h4");
       is(unsupportedDeviceName.textContent, fakeAdbDevice.model, "matching model for unsupported device");

--- a/test/mochitest/test_select_build.html
+++ b/test/mochitest/test_select_build.html
@@ -40,7 +40,7 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=1235459
   function assert_select_build(id, nbExpected, nameExpected, descExpected) {
     let devices = c.getElementById("devices");
     ok(devices, "has devices node");
-    is(devices.childNodes.length, nbExpected, "two builds available");
+    is(devices.childElementCount, nbExpected, "two builds available");
 
     let e = devices.getElementsByTagName("input")[id];
     ok(e, "has build id", id);


### PR DESCRIPTION
- Using documentFragment object instead of raw template.
- Unified drawBuild() and drawUnsupported().
- In addition, add/remove semicolons.
